### PR TITLE
Light refactoring to move some logic from the view layer into the store

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@webcomponents/webcomponentsjs": "^2.0.0-beta.2",
     "pwa-helpers": "polymerlabs/pwa-helpers",
     "redux": "^3.7.2",
-    "redux-thunk": "^2.2.0"
+    "redux-thunk": "^2.2.0",
+    "reselect": "^3.0.1"
   },
   "devDependencies": {
     "axe-core": "^3.0.0",

--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -10,8 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 export const UPDATE_PAGE = 'UPDATE_PAGE';
 export const UPDATE_OFFLINE = 'UPDATE_OFFLINE';
-export const OPEN_DRAWER = 'OPEN_DRAWER';
-export const CLOSE_DRAWER = 'CLOSE_DRAWER';
+export const UPDATE_DRAWER_STATE = 'UPDATE_DRAWER_STATE';
 export const OPEN_SNACKBAR = 'OPEN_SNACKBAR';
 export const CLOSE_SNACKBAR = 'CLOSE_SNACKBAR';
 
@@ -22,6 +21,9 @@ export const navigate = (path) => (dispatch) => {
   // Any other info you might want to extract from the path (like page type),
   // you can do here
   dispatch(loadPage(page));
+
+  // Close the drawer - in case the *path* change came from a link in the drawer.
+  dispatch(updateDrawerState(false));
 };
 
 const loadPage = (page) => async (dispatch) => {
@@ -52,18 +54,6 @@ const updatePage = (page) => {
   };
 }
 
-export const openDrawer = () => {
-  return {
-    type: OPEN_DRAWER
-  };
-};
-
-export const closeDrawer = () => {
-  return {
-    type: CLOSE_DRAWER
-  };
-};
-
 let snackbarTimer;
 
 export const showSnackbar = () => (dispatch) => {
@@ -76,8 +66,29 @@ export const showSnackbar = () => (dispatch) => {
 };
 
 export const updateOffline = (offline) => {
-  return {
-    type: UPDATE_OFFLINE,
-    offline
-  };
+  return (dispatch, getState) => {
+    // Show the snackbar, unless this is the first load of the page.
+    if (getState().app.offline !== undefined) {
+      dispatch(showSnackbar());
+    }
+    dispatch({
+      type: UPDATE_OFFLINE,
+      offline
+    });  
+  }
 };
+
+export const updateLayout = (wide) => (dispatch, getState) => {
+  if (getState().app.drawerOpened) {
+    dispatch(updateDrawerState(false));
+  }
+}
+
+export const updateDrawerState = (opened) => (dispatch, getState) => {
+  if (getState().app.drawerOpened !== opened) {
+    dispatch({
+      type: UPDATE_DRAWER_STATE,
+      opened
+    });
+  }
+}

--- a/src/components/my-view3.js
+++ b/src/components/my-view3.js
@@ -23,13 +23,13 @@ import { store } from '../store.js';
 import { checkout } from '../actions/shop.js';
 
 // We are lazy loading its reducer.
-import shop from '../reducers/shop.js';
+import shop, { cartQuantitySelector } from '../reducers/shop.js';
 store.addReducers({
   shop
 });
 
 class MyView3 extends connect(store)(PageViewElement) {
-  _render({_cart, _error}) {
+  _render({_quantity, _error}) {
     return html`
       ${SharedStyles}
       ${ButtonSharedStyles}
@@ -49,7 +49,7 @@ class MyView3 extends connect(store)(PageViewElement) {
 
       <section>
         <h2>Redux example: shopping cart</h2>
-        <div class="circle">${this._numItemsInCart(_cart)}</div>
+        <div class="circle">${_quantity}</div>
 
         <p>This is a slightly more advanced Redux example, that simulates a
           shopping cart: getting the products, adding/removing items to the
@@ -69,7 +69,7 @@ class MyView3 extends connect(store)(PageViewElement) {
         <div>${_error}</div>
         <br>
         <p>
-          <button class="checkout" hidden="${_cart.addedIds.length == 0}"
+          <button class="checkout" hidden="${_quantity == 0}"
               on-click="${() => store.dispatch(checkout())}">
             Checkout
           </button>
@@ -80,22 +80,14 @@ class MyView3 extends connect(store)(PageViewElement) {
 
   static get properties() { return {
     // This is the data from the store.
-    _cart: Object,
+    _quantity: Number,
     _error: String
   }}
 
   // This is called every time something is updated in the store.
   _stateChanged(state) {
-    this._cart = state.shop.cart;
+    this._quantity = cartQuantitySelector(state);
     this._error = state.shop.error;
-  }
-
-  _numItemsInCart(cart) {
-    let num = 0;
-    for (let id of cart.addedIds) {
-      num += cart.quantityById[id];
-    }
-    return num;
   }
 }
 

--- a/src/components/shop-products.js
+++ b/src/components/shop-products.js
@@ -30,7 +30,7 @@ class ShopProducts extends connect(store)(LitElement) {
             <shop-item name="${item.title}" amount="${item.inventory}" price="${item.price}"></shop-item>
             <button
                 disabled="${item.inventory === 0}"
-                on-click="${(e) => this._addToCart(e)}"
+                on-click="${(e) => store.dispatch(addToCart(e.currentTarget.dataset['index']))}"
                 data-index$="${item.id}"
                 title="${item.inventory === 0 ? 'Sold out' : 'Add to cart' }">
               ${item.inventory === 0 ? 'Sold out': addToCartIcon }
@@ -52,10 +52,6 @@ class ShopProducts extends connect(store)(LitElement) {
   // This is called every time something is updated in the store.
   _stateChanged(state) {
     this._products = state.shop.products;
-  }
-
-  _addToCart(event) {
-    store.dispatch(addToCart(event.currentTarget.dataset['index']));
   }
 }
 

--- a/src/reducers/app.js
+++ b/src/reducers/app.js
@@ -9,8 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import { UPDATE_PAGE, UPDATE_OFFLINE,
-         OPEN_DRAWER, CLOSE_DRAWER,
-         OPEN_SNACKBAR, CLOSE_SNACKBAR } from '../actions/app.js';
+         OPEN_SNACKBAR, CLOSE_SNACKBAR, UPDATE_DRAWER_STATE } from '../actions/app.js';
 
 const app = (state = {drawerOpened: false}, action) => {
   switch (action.type) {
@@ -24,16 +23,11 @@ const app = (state = {drawerOpened: false}, action) => {
         ...state,
         offline: action.offline
       };
-    case OPEN_DRAWER:
+    case UPDATE_DRAWER_STATE:
       return {
         ...state,
-        drawerOpened: true
-      };
-    case CLOSE_DRAWER:
-      return {
-        ...state,
-        drawerOpened: false
-      };
+        drawerOpened: action.opened
+      }
     case OPEN_SNACKBAR:
       return {
         ...state,

--- a/src/reducers/shop.js
+++ b/src/reducers/shop.js
@@ -138,9 +138,21 @@ const quantityById = (state = INITIAL_CART.quantityById, action) => {
 
 export default shop;
 
+// Per Redux best practices, the shop data in our store is structured
+// for efficiency (small size and fast updates).
+//
+// The _selectors_ below transform store data into specific forms that
+// are tailored for presentation. Putting this logic here keeps the
+// layers of our app loosely coupled and easier to maintain, since
+// views don't need to know about the store's internal data structures.
+//
+// We use a tiny library called `reselect` to create efficient
+// selectors. More info: https://github.com/reduxjs/reselect.
+
 const cartSelector = state => state.shop.cart;
 const productsSelector = state => state.shop.products;
 
+// Return a flattened array representation of the items in the cart
 export const cartItemsSelector = createSelector(
   cartSelector,
   productsSelector,
@@ -154,6 +166,7 @@ export const cartItemsSelector = createSelector(
   }
 );
 
+// Return the total cost of the items in the cart
 export const cartTotalSelector = createSelector(
   cartSelector,
   productsSelector,
@@ -167,6 +180,7 @@ export const cartTotalSelector = createSelector(
   }
 );
 
+// Return the number of items in the cart
 export const cartQuantitySelector = createSelector(
   cartSelector,
   cart => {

--- a/src/reducers/shop.js
+++ b/src/reducers/shop.js
@@ -9,6 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 import { GET_PRODUCTS, ADD_TO_CART, REMOVE_FROM_CART, CHECKOUT_SUCCESS, CHECKOUT_FAILURE } from '../actions/shop.js';
+import { createSelector } from 'reselect';
 
 const INITIAL_CART = {
   addedIds: [],
@@ -136,3 +137,43 @@ const quantityById = (state = INITIAL_CART.quantityById, action) => {
 }
 
 export default shop;
+
+const cartSelector = state => state.shop.cart;
+const productsSelector = state => state.shop.products;
+
+export const cartItemsSelector = createSelector(
+  cartSelector,
+  productsSelector,
+  (cart, products) => {
+    const items = [];
+    for (let id of cart.addedIds) {
+      const item = products[id];
+      items.push({id: item.id, title: item.title, amount: cart.quantityById[id], price: item.price});
+    }
+    return items;
+  }
+);
+
+export const cartTotalSelector = createSelector(
+  cartSelector,
+  productsSelector,
+  (cart, products) => {
+    let total = 0;
+    for (let id of cart.addedIds) {
+      const item = products[id];
+      total += item.price * cart.quantityById[id];
+    }
+    return parseFloat(Math.round(total * 100) / 100).toFixed(2);
+  }
+);
+
+export const cartQuantitySelector = createSelector(
+  cartSelector,
+  cart => {
+    let num = 0;
+    for (let id of cart.addedIds) {
+      num += cart.quantityById[id];
+    }
+    return num;  
+  }
+)


### PR DESCRIPTION
This PR moves some logic from the view layer into the store.

The goal is to make the separation between the data layer and the view layer a bit cleaner and make the view components easier to grok at a glance; for the most part, they only implement LitElement lifecycle methods and `stateChanged()`.