### PR TITLE
Simplify curried function declaration in app action

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -65,17 +65,15 @@ export const showSnackbar = () => (dispatch) => {
     dispatch({ type: CLOSE_SNACKBAR }), 3000);
 };
 
-export const updateOffline = (offline) => {
-  return (dispatch, getState) => {
-    // Show the snackbar, unless this is the first load of the page.
-    if (getState().app.offline !== undefined) {
-      dispatch(showSnackbar());
-    }
-    dispatch({
-      type: UPDATE_OFFLINE,
-      offline
-    });  
+export const updateOffline = (offline) => (dispatch, getState) => {
+  // Show the snackbar, unless this is the first load of the page.
+  if (getState().app.offline !== undefined) {
+    dispatch(showSnackbar());
   }
+  dispatch({
+    type: UPDATE_OFFLINE,
+    offline
+  });
 };
 
 export const updateLayout = (wide) => (dispatch, getState) => {


### PR DESCRIPTION
While browsing through the source code I came across this function. The `return` was probably left-over from earlier debugging. It is now in style with the other curried function declarations.