### PR TITLE
Add crossorigin to script type=module

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <!-- Load webcomponents-loader.js to check and load any polyfills your browser needs -->
     <script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
     <!-- Built with love using PWA Starter Kit -->
-    <script type="module" src="src/components/my-app.js"></script>
+    <script type="module" src="src/components/my-app.js" crossorigin></script>
   </body>
 </html>


### PR DESCRIPTION
Fixes #89.

Unlike a regular `<script>`, by default [`<script type="module">` doesn't include credentials](https://jakearchibald.com/2017/es-modules-in-browsers/#no-credentials), so network requests for scripts will fail if they depend on credentials (e.g. the [Cloud Shell web preview service](https://cloud.google.com/shell/docs/features#web_preview)). This PR adds the `crossorigin` attribute to fix this, which won't be any different than transforming to AMD modules (on browsers without native ES modules) that use regular `<script>`s.