### PR TITLE
change the order of import and updatePage

### DIFF
--- a/src/actions/app.js
+++ b/src/actions/app.js
@@ -27,6 +27,14 @@ export const navigate = (path) => (dispatch) => {
 };
 
 const loadPage = (page) => async (dispatch) => {
+  // If the page is invalid, set to 404. The is also a good spot to check
+  // other location things like sub-path or query params.
+  if (['view1', 'view2', 'view3'].indexOf(page) === -1) {
+    page = 'view404';
+  }
+
+  dispatch(updatePage(page));
+
   switch(page) {
     case 'view1':
       await import('../components/my-view1.js');
@@ -40,11 +48,8 @@ const loadPage = (page) => async (dispatch) => {
       await import('../components/my-view3.js');
       break;
     default:
-      page = 'view404';
       await import('../components/my-view404.js');
   }
-
-  dispatch(updatePage(page));
 }
 
 const updatePage = (page) => {


### PR DESCRIPTION
Currently when a page is selected (e.g. clicking on the `View Two` tab), the app will try to import the page js (eg. my-view2.js) and wait for all the modules to be loaded and evaluated before setting the state `app.page` to `view2`.  This has a side effect of making the first render call of <my-view2> to be skipped since `app.page` hasn't updated yet right after the page is loaded and evaluated, and thus `_shouldRender` will return false. And only after `app.page` is updated to `view2` then `<my-view2>` will start to render its template, and that is the second render call.

I am proposing we should update the `app.page` state before the `import()`. This will fix https://github.com/Polymer/pwa-starter-kit/issues/93. It also has an advantage of making the UI feels more responsive as the tab selection will now update immediately after the user's click, instead of having to wait for the module to download and evaluate, and that could be quite noticeable in a slow connection.
