### PR TITLE
Minor changes to visual-semantics in layout and behavior of view2 following certain conventions

### DIFF
--- a/src/components/counter-element.js
+++ b/src/components/counter-element.js
@@ -25,9 +25,8 @@ class CounterElement extends LitElement {
       <div>
         <p>
           Clicked: <span>${props.clicks}</span> times.
-          Value is <span>${props.value}</span>.
-          <button on-click="${() => this._onIncrement()}" title="Add 1">${plusIcon}</button>
           <button on-click="${() => this._onDecrement()}" title="Minus 1">${minusIcon}</button>
+          <button on-click="${() => this._onIncrement()}" title="Add 1">${plusIcon}</button>
         </p>
       </div>
     `;

--- a/src/components/counter-element.js
+++ b/src/components/counter-element.js
@@ -25,8 +25,9 @@ class CounterElement extends LitElement {
       <div>
         <p>
           Clicked: <span>${props.clicks}</span> times.
-          <button on-click="${() => this._onDecrement()}" title="Minus 1">${minusIcon}</button>
+          Value is <span>${props.value}</span>.
           <button on-click="${() => this._onIncrement()}" title="Add 1">${plusIcon}</button>
+          <button on-click="${() => this._onDecrement()}" title="Minus 1">${minusIcon}</button>
         </p>
       </div>
     `;

--- a/src/components/my-view2.js
+++ b/src/components/my-view2.js
@@ -32,20 +32,20 @@ class MyView2 extends connect(store)(PageViewElement) {
       ${SharedStyles}
       <section>
         <h2>Redux example: simple counter</h2>
-        <div class="circle">${props._value}</div>
+        <div class="circle">${props._clicks}</div>
         <p>This page contains a reusable <code>&lt;counter-element&gt;</code>. The
         element is not built in a Redux-y way (you can think of it as being a
         third-party element you got from someone else), but this page is connected to the
         Redux store. When the element updates its counter, this page updates the values
-        in the Redux store, and you can see the current value of the counter reflected in
+        in the Redux store, and you can see the total number of clicks reflected in
         the bubble above.</p>
         <br><br>
       </section>
       <section>
         <p>
           <counter-element value="${props._value}" clicks="${props._clicks}"
-              on-counter-decremented="${() => store.dispatch(decrement())}"
-              on-counter-incremented="${() => store.dispatch(increment())}">
+              on-counter-incremented="${() => store.dispatch(increment())}"
+              on-counter-decremented="${() => store.dispatch(decrement())}">
           </counter-element>
         </p>
       </section>

--- a/src/components/my-view2.js
+++ b/src/components/my-view2.js
@@ -32,20 +32,20 @@ class MyView2 extends connect(store)(PageViewElement) {
       ${SharedStyles}
       <section>
         <h2>Redux example: simple counter</h2>
-        <div class="circle">${props._clicks}</div>
+        <div class="circle">${props._value}</div>
         <p>This page contains a reusable <code>&lt;counter-element&gt;</code>. The
         element is not built in a Redux-y way (you can think of it as being a
         third-party element you got from someone else), but this page is connected to the
         Redux store. When the element updates its counter, this page updates the values
-        in the Redux store, and you can see the total number of clicks reflected in
+        in the Redux store, and you can see the current value of the counter reflected in
         the bubble above.</p>
         <br><br>
       </section>
       <section>
         <p>
           <counter-element value="${props._value}" clicks="${props._clicks}"
-              on-counter-incremented="${() => store.dispatch(increment())}"
-              on-counter-decremented="${() => store.dispatch(decrement())}">
+              on-counter-decremented="${() => store.dispatch(decrement())}"
+              on-counter-incremented="${() => store.dispatch(increment())}">
           </counter-element>
         </p>
       </section>

--- a/src/components/my-view2.js
+++ b/src/components/my-view2.js
@@ -32,12 +32,12 @@ class MyView2 extends connect(store)(PageViewElement) {
       ${SharedStyles}
       <section>
         <h2>Redux example: simple counter</h2>
-        <div class="circle">${props._clicks}</div>
+        <div class="circle">${props._value}</div>
         <p>This page contains a reusable <code>&lt;counter-element&gt;</code>. The
         element is not built in a Redux-y way (you can think of it as being a
         third-party element you got from someone else), but this page is connected to the
         Redux store. When the element updates its counter, this page updates the values
-        in the Redux store, and you can see the total number of clicks reflected in
+        in the Redux store, and you can see the current value of the counter reflected in
         the bubble above.</p>
         <br><br>
       </section>


### PR DESCRIPTION
Changed the value property of `counter-element` in `my-view2.js` to reflect `props._value`.

It's the value that the end-user is likely to be interested in, and clicks are not usually relevant as a visual quantity.

The (+) and (-) buttons should produce a distinctly visible change to be more effective i.e. the (-) button should decrement something, and since the number of clicks cannot be decremented, it counter-intuitively seems to do nothing.

Removed repeated display of the value near the buttons, as it's unnecessarily confusing. It makes sense that the input area shows input-related data and the main display area shows the stored data, thereby also reinforcing the feeling that the data is being updated somewhere else, namely the redux store.

Changed the body text to reflect the changes.

Swapped the order of the (+) and (-) buttons, as conventionally the right-side is visually associated with 'positive' and 'increment'.

Changed the order of the dispatches to 'increment' and 'decrement' in `my-view2.js` to reflect the button-order change.

Caveats: view3 needs to be re-thought/organised if similar conventions are followed.