### PR TITLE
use single -s arg with comma separated list of sauce browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "npm run test:unit && npm run test:integration",
     "test:integration": "mocha test/integration --timeout=10000",
     "test:unit": "polymer test --module-resolution=node --npm",
-    "test:sauce": "polymer test --module-resolution=node --npm -s 'windows 10/microsoftedge@17' -s 'macos 10.13/safari@11'",
+    "test:sauce": "polymer test --module-resolution=node --npm -s 'windows 10/microsoftedge@17,macos 10.13/safari@11'",
     "test:regenerate_screenshots": "mocha test/integration/screenshots-baseline/regenerate.js --timeout=15000"
   },
   "dependencies": {


### PR DESCRIPTION
From @usergenic 's comment: https://github.com/Polymer/pwa-starter-kit/pull/155#pullrequestreview-128988381
See if this fixes the test issue.
