### PR TITLE
Remove `minimum-scale=1,user-scalable=yes` from viewport <meta>

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="generator" content="PWA Starter Kit">
-    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-
     <title>My app</title>
+    <meta name="generator" content="PWA Starter Kit">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="description" content="My App description">
 
     <!--

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <meta charset="utf-8">
     <title>My app</title>
     <meta name="generator" content="PWA Starter Kit">
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="description" content="My App description">
 
     <!--

--- a/test/unit/counter-element.html
+++ b/test/unit/counter-element.html
@@ -12,9 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-
     <title>my-view1</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     <script src="../../node_modules/wct-browser-legacy/browser.js"></script>

--- a/test/unit/counter-element.html
+++ b/test/unit/counter-element.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <head>
     <meta charset="utf-8">
     <title>my-view1</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     <script src="../../node_modules/wct-browser-legacy/browser.js"></script>

--- a/test/unit/index.html
+++ b/test/unit/index.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <head>
     <meta charset="utf-8">
     <title>Tests</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   </head>
   <body>

--- a/test/unit/index.html
+++ b/test/unit/index.html
@@ -12,8 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
     <title>Tests</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
     <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
   </head>
   <body>

--- a/test/unit/views-a11y.html
+++ b/test/unit/views-a11y.html
@@ -13,7 +13,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <head>
     <meta charset="utf-8">
     <title>views a11y</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <script>
       // Redux assumes `process.env.NODE_ENV` exists in the ES module build.

--- a/test/unit/views-a11y.html
+++ b/test/unit/views-a11y.html
@@ -12,9 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-
     <title>views a11y</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <script>
       // Redux assumes `process.env.NODE_ENV` exists in the ES module build.


### PR DESCRIPTION
Hey y’all!

I wanted to open a discussion on simplifying the viewport `<meta>` tag.

Two parts seem unnecessary: `user-scalable=yes` is the implicit default, and `minimum-scale=1` prevents zooming out for no good reason that I can think of.

This is how we’ve always done it in the good ol’ HTML5  Boilerplate:

```html
<meta name="viewport" content="width=device-width,initial-scale=1">
```

What do you think?