### PR TITLE
Update shared-styles.js w/ rems & unitless values instead of pixels

### DIFF
--- a/src/components/shared-styles.js
+++ b/src/components/shared-styles.js
@@ -18,12 +18,12 @@ export const SharedStyles = html`
   }
 
   section {
-    padding: 24px;
+    padding: 1.5rem;
     background: var(--app-section-odd-color);
   }
 
   section > * {
-    max-width: 600px;
+    max-width: 37.5rem;
     margin-right: auto;
     margin-left: auto;
   }
@@ -33,28 +33,28 @@ export const SharedStyles = html`
   }
 
   h2 {
-    font-size: 24px;
+    font-size: 1.5rem;
     text-align: center;
     color: var(--app-dark-text-color);
   }
 
   @media (min-width: 460px) {
     h2 {
-      font-size: 36px;
+      font-size: 2.25rem;
     }
   }
 
   .circle {
     display: block;
-    width: 64px;
-    height: 64px;
+    width: 4rem;
+    height: 4rem;
     margin: 0 auto;
     text-align: center;
     border-radius: 50%;
     background: var(--app-primary-color);
     color: var(--app-light-text-color);
-    font-size: 30px;
-    line-height: 64px;
+    font-size: 1.875rem;
+    line-height: 4rem;
   }
 </style>
 `;


### PR DESCRIPTION
## Summary of changes
Change primary units used in the shared styles stylesheet to be rems & unitless values instead of pixels (px). 

- Align better with ubiquitous  CSS conventions for line-height to be unitless,  relative to font-size automatically

- Align better with best CSS practices to have media queries in ems instead of pixels [for the sake of accuracy in RWD use cases with improved a11y support using `rem`](https://zellwk.com/blog/media-query-units/)

- Be consistent with a11y best practices abstractions being applied/available in the test suite but not done for the shared CSS styles leading to cognitive noise. 

- More flexible shared styles to font-size preferences & so on by using `rem`. 

## Steps to apply changes
- [x] Change font-size & padding to use `rem` instead of pixels within `shared-styles.js`
- [x] Change media queries to use `em` instead of pixels within `shared-styles.js`

## Things potentially to be discussed
- For devs who don't know better or aren't familiar with RWD where rem & em use is ubiquitous, have comments of the pixel values?
- Do the same now for `my-app.js`, which will the sole component with pixels used for font-sizes & etc or in a different PR?

