### PR TITLE
Add a sensible z-index to app-drawer to ensure it being on top of the contents of page components

### DIFF
--- a/src/components/my-app.js
+++ b/src/components/my-app.js
@@ -36,7 +36,7 @@ import { menuIcon } from './my-icons.js';
 import './snack-bar.js';
 
 class MyApp extends connect(store)(LitElement) {
-  _render({appTitle, _page, _drawerOpened, _snackbarOpened, _offline}) {
+  _render({ appTitle, _page, _drawerOpened, _snackbarOpened, _offline }) {
     // Anything that's related to rendering should be done in here.
     return html`
     <style>
@@ -58,6 +58,10 @@ class MyApp extends connect(store)(LitElement) {
         --app-drawer-background-color: var(--app-secondary-color);
         --app-drawer-text-color: var(--app-light-text-color);
         --app-drawer-selected-color: #78909C;
+      }
+
+      app-drawer {
+        z-index: 1;
       }
 
       app-header {
@@ -243,16 +247,16 @@ class MyApp extends connect(store)(LitElement) {
     installRouter((location) => store.dispatch(navigate(window.decodeURIComponent(location.pathname))));
     installOfflineWatcher((offline) => store.dispatch(updateOffline(offline)));
     installMediaQueryWatcher(`(min-width: 460px)`,
-        (matches) => store.dispatch(updateLayout(matches)));
+      (matches) => store.dispatch(updateLayout(matches)));
   }
 
   _didRender(properties, changeList) {
     if ('_page' in changeList) {
       const pageTitle = properties.appTitle + ' - ' + changeList._page;
       updateMetadata({
-          title: pageTitle,
-          description: pageTitle
-          // This object also takes an image property, that points to an img src.
+        title: pageTitle,
+        description: pageTitle
+        // This object also takes an image property, that points to an img src.
       });
     }
   }


### PR DESCRIPTION
## Summary of Change
- Adds `z-index: 1` to fix an issue of the children of a page component end up being over app-drawer—especially if `contain: content` is used on any of the children.

- Ensures expectations that the z-index of app-drawer is by default higher than the contents of `main` within `my-app`. 

## Actions taken by change
- [x] Add `z-index: 1` to app-drawer in shared 

## Questions to consider during review
- I'm running on empty, but I want to say in hindsight that `app-drawer` selector change should be in `my-app.js` `render` function. 