### PR TITLE
Add import syntax to import shop-item.js

### DIFF
--- a/src/components/shop-products.js
+++ b/src/components/shop-products.js
@@ -14,6 +14,9 @@ import { connect } from 'pwa-helpers/connect-mixin.js';
 // This element is connected to the Redux store.
 import { store } from '../store.js';
 
+// These are the elements needed by this element.
+import './shop-item.js';
+
 // These are the actions needed by this element.
 import { getAllProducts, addToCart } from '../actions/shop.js';
 


### PR DESCRIPTION
Hey guys.

Not find import syntax for solve shop-item element on shop-products.js. 
The reason why it should be solved is because it imported by shop-cart.js.

I think shop-products.js need import syntax for solve shop-item element too.

Thank you