### PR TITLE
Update Redux to v4 and Redux Thunk to v2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5788,12 +5788,8 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-    },
-    "lodash-es": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.10.tgz",
-      "integrity": "sha512-iesFYPmxYYGTcmQK0sL8bX3TGHyM6b2qREaB4kamHfQyfPJP0xgoGxp19nsH16nsfquLdiyKyX3mQkfiSGV8Rg=="
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -20192,14 +20188,12 @@
       "dev": true
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
         "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "symbol-observable": "^1.2.0"
       }
     },
     "redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "@polymer/lit-element": "^0.5.2",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "pwa-helpers": "^0.8.2",
-    "redux": "^3.7.2",
-    "redux-thunk": "^2.2.0",
+    "redux": "^4.0.0",
+    "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Since `redux-devtools-extension` has been updated on the Chrome Web Store and it is now compatible with Redux 4, it is now safe to update the Starter Kit dependency too. As already discussed in the issue, there are no changes needed to make the Starter Kit work with Redux 4. `redux-thunk` has been updated just for completeness, since its only change is the update of its TypeScript typings to Redux 4. The project has been tested on both Chrome `v67.0.3396.99` and Chrome Canary `v70.0.3501.0` with Redux DevTools `v2.15.3`, and everything kept working like a charm.

- [Redux v4 changelog](https://github.com/reduxjs/redux/releases/tag/v4.0.0)
- [Redux Thunk v2.3 changelog](https://github.com/reduxjs/redux-thunk/releases/tag/v2.3.0)

Fixes: https://github.com/Polymer/pwa-starter-kit/issues/76
