### PR TITLE
minor style update on the search field

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -97,13 +97,19 @@ a {
 
 #searchBox {
   display: inline-block;
+  width: 200px;
   background: white;
   border: none;
   font-family: inherit;
   font-size: inherit;
   color: black;
-  padding: 0 12px;
+  margin: 0 10px;
   border-bottom: 1px solid black;
+  -webkit-appearance: textfield;
+}
+
+#searchBox::-webkit-search-decoration {
+  -webkit-appearance: none;
 }
 
 /* home page */


### PR DESCRIPTION
- Currently the search field is a bit too long on other browsers not Chrome. Fix by having a fixed width on input.
- On Safari, setting border: 0 is not enough, need to use -webkit-appearance trick.
- Make input bottom border aligned with the label


<img width="1123" alt="screen shot 2018-07-31 at 10 01 58 am" src="https://user-images.githubusercontent.com/116360/43474921-0eb87348-94a9-11e8-8f0a-8a5c0a439132.png">

