### PR TITLE
Update app engine config to support standard env

### DIFF
--- a/server/app.yaml
+++ b/server/app.yaml
@@ -1,4 +1,1 @@
-runtime: nodejs
-env: flex
-automatic_scaling:
-  min_num_instances: 1
+runtime: nodejs8


### PR DESCRIPTION
Change to the standard environment in app engine, so the deployment could be simplified and lowering the initial cost (since standard environment GAE get free instance hour)