### PR TITLE
Ignore the .d.ts, .js & .js.map just in src folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ node_modules/
 test/integration/screenshots-current/
 _site/
 .DS_Store
-**/*.d.ts
-**/*.js
-**/*.js.map
+src/**/*.d.ts
+src/**/*.js
+src/**/*.js.map


### PR DESCRIPTION
If not other files like `gulpfile.js`, `service-worker.js` and `sw-precache-config.js` will be ignored.