### PR TITLE
Update deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -950,11 +950,11 @@
       }
     },
     "@polymer/lit-element": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@polymer/lit-element/-/lit-element-0.6.1.tgz",
-      "integrity": "sha512-eselNs2lA4n1R1rSyPXW8XR3ISmbYVQcDtIMSINHVNZ56pCtCHOtgmaG8C4k0gONwikEMJTP9blNHD/gdYIxFA==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@polymer/lit-element/-/lit-element-0.6.2.tgz",
+      "integrity": "sha512-4NWvK6SyAyyeW1mQ24ZVR+rtqZNHZ2JWnVTsPF/1iXnmmPwnpLs8mz0HRqz5adyoyt96ed/y2dsDwGBktJYyew==",
       "requires": {
-        "lit-html": "^0.11.4"
+        "lit-html": "^0.12.0"
       }
     },
     "@polymer/polymer": {
@@ -5776,9 +5776,9 @@
       }
     },
     "lit-html": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-0.11.4.tgz",
-      "integrity": "sha512-yfJUxQrRjhYo4cdz3Db9YlkHs9v+rTZA4fvE/dqCOrA1Q2Bmx52X2OtEgGQ+JhyCb6ddDTndLijZjsSoQ44G7Q=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-0.12.0.tgz",
+      "integrity": "sha512-NyFgq8yTlGEjUFQOmNnK/kj+ZdDVJzTwsLunNSewGiOns7SjuJi6ymCCqzZZ81uW2VwEmliMbOlFZc9QmOJPLA=="
     },
     "load-json-file": {
       "version": "1.1.0",
@@ -19634,9 +19634,9 @@
       }
     },
     "pwa-helpers": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/pwa-helpers/-/pwa-helpers-0.8.4.tgz",
-      "integrity": "sha512-PluAQZo8a6GqcdIa0a61JabSHiKjmF1zuiGtAznDaUotD5dGA9OK4MbH++2cxig70vHg0sZemyeS4kzeVIK+0g=="
+      "version": "0.9.0-pre.2",
+      "resolved": "https://registry.npmjs.org/pwa-helpers/-/pwa-helpers-0.9.0-pre.2.tgz",
+      "integrity": "sha512-VlKDNPDaWtIcRNDhPo3iBz3bpYfjxsNyoTIpKaA8FlGb7Mz7iN/vCvbfjXl1oUkS/4ODfRXjQVHtiKDiK9bYwA=="
     },
     "qs": {
       "version": "6.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-starter-kit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -19634,9 +19634,9 @@
       }
     },
     "pwa-helpers": {
-      "version": "0.9.0-pre.2",
-      "resolved": "https://registry.npmjs.org/pwa-helpers/-/pwa-helpers-0.9.0-pre.2.tgz",
-      "integrity": "sha512-VlKDNPDaWtIcRNDhPo3iBz3bpYfjxsNyoTIpKaA8FlGb7Mz7iN/vCvbfjXl1oUkS/4ODfRXjQVHtiKDiK9bYwA=="
+      "version": "0.9.0-pre.4",
+      "resolved": "https://registry.npmjs.org/pwa-helpers/-/pwa-helpers-0.9.0-pre.4.tgz",
+      "integrity": "sha512-V0EziCG4yq3S6G3QRdqqeyttXy7KBtzbc2M9u90d0QW1Ki2WV9IGGekpHBQ7ADBSv8ibYFOnmlrbXsXNvMeqIQ=="
     },
     "qs": {
       "version": "6.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19634,9 +19634,9 @@
       }
     },
     "pwa-helpers": {
-      "version": "0.9.0-pre.4",
-      "resolved": "https://registry.npmjs.org/pwa-helpers/-/pwa-helpers-0.9.0-pre.4.tgz",
-      "integrity": "sha512-V0EziCG4yq3S6G3QRdqqeyttXy7KBtzbc2M9u90d0QW1Ki2WV9IGGekpHBQ7ADBSv8ibYFOnmlrbXsXNvMeqIQ=="
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/pwa-helpers/-/pwa-helpers-0.9.0.tgz",
+      "integrity": "sha512-lFj0udSHHqEJdf+SmAp8Y9yRJ8s1ieQIbvt4mWXn6NXUOO9ntLXNLBi8PMJGBPkc32cG4nJ6yuJrHzOxC5ZTXw=="
     },
     "qs": {
       "version": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "dependencies": {
     "@polymer/app-layout": "^3.0.0",
-    "@polymer/lit-element": "^0.6.1",
+    "@polymer/lit-element": "^0.6.2",
     "@polymer/polymer": "^3.0.0",
     "@webcomponents/webcomponentsjs": "^2.0.0",
-    "pwa-helpers": "^0.8.4",
+    "pwa-helpers": "^0.9.0-pre.2",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@polymer/lit-element": "^0.6.2",
     "@polymer/polymer": "^3.0.0",
     "@webcomponents/webcomponentsjs": "^2.0.0",
-    "pwa-helpers": "^0.9.0-pre.4",
+    "pwa-helpers": "^0.9.0",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pwa-starter-kit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "contributors": [
     "The Polymer Authors"
   ],
@@ -24,7 +24,7 @@
     "@polymer/lit-element": "^0.6.2",
     "@polymer/polymer": "^3.0.0",
     "@webcomponents/webcomponentsjs": "^2.0.0",
-    "pwa-helpers": "^0.9.0-pre.2",
+    "pwa-helpers": "^0.9.0-pre.4",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1"

--- a/src/components/counter-element.js
+++ b/src/components/counter-element.js
@@ -30,8 +30,8 @@ class CounterElement extends LitElement {
         <p>
           Clicked: <span>${this.clicks}</span> times.
           Value is <span>${this.value}</span>.
-          <button @click="${() => this._onIncrement()}" title="Add 1">${plusIcon}</button>
-          <button @click="${() => this._onDecrement()}" title="Minus 1">${minusIcon}</button>
+          <button @click="${this._onIncrement}" title="Add 1">${plusIcon}</button>
+          <button @click="${this._onDecrement}" title="Minus 1">${minusIcon}</button>
         </p>
       </div>
     `;

--- a/src/components/my-app.js
+++ b/src/components/my-app.js
@@ -36,7 +36,6 @@ import './snack-bar.js';
 
 class MyApp extends connect(store)(LitElement) {
   render() {
-    const {appTitle, _page, _drawerOpened, _snackbarOpened, _offline} = this;
     // Anything that's related to rendering should be done in here.
     return html`
     <style>
@@ -183,42 +182,42 @@ class MyApp extends connect(store)(LitElement) {
     <!-- Header -->
     <app-header condenses reveals effects="waterfall">
       <app-toolbar class="toolbar-top">
-        <button class="menu-btn" title="Menu" @click="${() => store.dispatch(updateDrawerState(true))}">${menuIcon}</button>
-        <div main-title>${appTitle}</div>
+        <button class="menu-btn" title="Menu" @click="${this._menuButtonClicked}">${menuIcon}</button>
+        <div main-title>${this.appTitle}</div>
       </app-toolbar>
 
       <!-- This gets hidden on a small screen-->
       <nav class="toolbar-list">
-        <a ?selected="${_page === 'view1'}" href="/view1">View One</a>
-        <a ?selected="${_page === 'view2'}" href="/view2">View Two</a>
-        <a ?selected="${_page === 'view3'}" href="/view3">View Three</a>
+        <a ?selected="${this._page === 'view1'}" href="/view1">View One</a>
+        <a ?selected="${this._page === 'view2'}" href="/view2">View Two</a>
+        <a ?selected="${this._page === 'view3'}" href="/view3">View Three</a>
       </nav>
     </app-header>
 
     <!-- Drawer content -->
-    <app-drawer .opened="${_drawerOpened}"
-        @opened-changed="${e => store.dispatch(updateDrawerState(e.target.opened))}">
+    <app-drawer .opened="${this._drawerOpened}"
+        @opened-changed="${this._drawerOpenedChanged}">
       <nav class="drawer-list">
-        <a ?selected="${_page === 'view1'}" href="/view1">View One</a>
-        <a ?selected="${_page === 'view2'}" href="/view2">View Two</a>
-        <a ?selected="${_page === 'view3'}" href="/view3">View Three</a>
+        <a ?selected="${this._page === 'view1'}" href="/view1">View One</a>
+        <a ?selected="${this._page === 'view2'}" href="/view2">View Two</a>
+        <a ?selected="${this._page === 'view3'}" href="/view3">View Three</a>
       </nav>
     </app-drawer>
 
     <!-- Main content -->
     <main role="main" class="main-content">
-      <my-view1 class="page" ?active="${_page === 'view1'}"></my-view1>
-      <my-view2 class="page" ?active="${_page === 'view2'}"></my-view2>
-      <my-view3 class="page" ?active="${_page === 'view3'}"></my-view3>
-      <my-view404 class="page" ?active="${_page === 'view404'}"></my-view404>
+      <my-view1 class="page" ?active="${this._page === 'view1'}"></my-view1>
+      <my-view2 class="page" ?active="${this._page === 'view2'}"></my-view2>
+      <my-view3 class="page" ?active="${this._page === 'view3'}"></my-view3>
+      <my-view404 class="page" ?active="${this._page === 'view404'}"></my-view404>
     </main>
 
     <footer>
       <p>Made with &hearts; by the Polymer team.</p>
     </footer>
 
-    <snack-bar ?active="${_snackbarOpened}">
-        You are now ${_offline ? 'offline' : 'online'}.</snack-bar>
+    <snack-bar ?active="${this._snackbarOpened}">
+        You are now ${this._offline ? 'offline' : 'online'}.</snack-bar>
     `;
   }
 
@@ -257,7 +256,15 @@ class MyApp extends connect(store)(LitElement) {
     }
   }
 
-  _stateChanged(state) {
+  _menuButtonClicked() {
+    store.dispatch(updateDrawerState(true));
+  }
+
+  _drawerOpenedChanged(e) {
+    store.dispatch(updateDrawerState(e.target.opened));
+  }
+
+  stateChanged(state) {
     this._page = state.app.page;
     this._offline = state.app.offline;
     this._snackbarOpened = state.app.snackbarOpened;

--- a/src/components/my-view2.js
+++ b/src/components/my-view2.js
@@ -48,8 +48,8 @@ class MyView2 extends connect(store)(PageViewElement) {
       <section>
         <p>
           <counter-element value="${this._value}" clicks="${this._clicks}"
-              @counter-incremented="${() => store.dispatch(increment())}"
-              @counter-decremented="${() => store.dispatch(decrement())}">
+              @counter-incremented="${this._counterIncremented}"
+              @counter-decremented="${this._counterDecremented}">
           </counter-element>
         </p>
       </section>
@@ -62,8 +62,16 @@ class MyView2 extends connect(store)(PageViewElement) {
     _value: { type: Number },
   }}
 
+  _counterIncremented() {
+    store.dispatch(increment());
+  }
+
+  _counterDecremented() {
+    store.dispatch(decrement());
+  }
+
   // This is called every time something is updated in the store.
-  _stateChanged(state) {
+  stateChanged(state) {
     this._clicks = state.counter.clicks;
     this._value = state.counter.value;
   }

--- a/src/components/my-view3.js
+++ b/src/components/my-view3.js
@@ -35,7 +35,6 @@ import { addToCartIcon } from './my-icons.js';
 
 class MyView3 extends connect(store)(PageViewElement) {
   render() {
-    const {_quantity, _error} = this;
     return html`
       ${SharedStyles}
       ${ButtonSharedStyles}
@@ -66,7 +65,7 @@ class MyView3 extends connect(store)(PageViewElement) {
 
       <section>
         <h2>Redux example: shopping cart</h2>
-        <div class="cart">${addToCartIcon}<div class="circle small">${_quantity}</div></div>
+        <div class="cart">${addToCartIcon}<div class="circle small">${this._quantity}</div></div>
         <p>This is a slightly more advanced Redux example, that simulates a
           shopping cart: getting the products, adding/removing items to the
           cart, and a checkout action, that can sometimes randomly fail (to
@@ -82,11 +81,10 @@ class MyView3 extends connect(store)(PageViewElement) {
         <h3>Your Cart</h3>
         <shop-cart></shop-cart>
 
-        <div>${_error}</div>
+        <div>${this._error}</div>
         <br>
         <p>
-          <button ?hidden="${_quantity == 0}"
-              @click="${() => store.dispatch(checkout())}">
+          <button ?hidden="${this._quantity == 0}" @click="${this._checkoutButtonClicked}">
             Checkout
           </button>
         </p>
@@ -100,8 +98,12 @@ class MyView3 extends connect(store)(PageViewElement) {
     _error: { type: String },
   }}
 
+  _checkoutButtonClicked() {
+    store.dispatch(checkout());
+  }
+
   // This is called every time something is updated in the store.
-  _stateChanged(state) {
+  stateChanged(state) {
     this._quantity = cartQuantitySelector(state);
     this._error = state.shop.error;
   }

--- a/src/components/shop-cart.js
+++ b/src/components/shop-cart.js
@@ -29,19 +29,18 @@ import { ButtonSharedStyles } from './button-shared-styles.js';
 
 class ShopCart extends connect(store)(LitElement) {
   render() {
-    const {_items, _total} = this;
     return html`
       ${ButtonSharedStyles}
       <style>
         :host { display: block; }
       </style>
-      <p ?hidden="${_items.length !== 0}">Please add some products to cart.</p>
-      ${_items.map((item) =>
+      <p ?hidden="${this._items.length !== 0}">Please add some products to cart.</p>
+      ${this._items.map((item) =>
         html`
           <div>
             <shop-item .name="${item.title}" .amount="${item.amount}" .price="${item.price}"></shop-item>
             <button
-                @click="${(e) => store.dispatch(removeFromCart(e.currentTarget.dataset['index']))}"
+                @click="${this._removeButtonClicked}"
                 data-index="${item.id}"
                 title="Remove from cart">
               ${removeFromCartIcon}
@@ -49,7 +48,7 @@ class ShopCart extends connect(store)(LitElement) {
           </div>
         `
       )}
-      <p ?hidden="${!_items.length}"><b>Total:</b> ${_total}</p>
+      <p ?hidden="${!this._items.length}"><b>Total:</b> ${this._total}</p>
     `;
   }
 
@@ -58,8 +57,12 @@ class ShopCart extends connect(store)(LitElement) {
     _total: { type: Number }
   }}
 
+  _removeButtonClicked(e) {
+    store.dispatch(removeFromCart(e.currentTarget.dataset['index']));
+  }
+
   // This is called every time something is updated in the store.
-  _stateChanged(state) {
+  stateChanged(state) {
     this._items = cartItemsSelector(state);
     this._total = cartTotalSelector(state);
   }

--- a/src/components/shop-products.js
+++ b/src/components/shop-products.js
@@ -40,7 +40,7 @@ class ShopProducts extends connect(store)(LitElement) {
             <shop-item name="${item.title}" amount="${item.inventory}" price="${item.price}"></shop-item>
             <button
                 .disabled="${item.inventory === 0}"
-                @click="${(e) => store.dispatch(addToCart(e.currentTarget.dataset['index']))}"
+                @click="${this._addButtonClicked}"
                 data-index="${item.id}"
                 title="${item.inventory === 0 ? 'Sold out' : 'Add to cart' }">
               ${item.inventory === 0 ? 'Sold out': addToCartIcon }
@@ -59,8 +59,12 @@ class ShopProducts extends connect(store)(LitElement) {
     store.dispatch(getAllProducts());
   }
 
+  _addButtonClicked(e) {
+    store.dispatch(addToCart(e.currentTarget.dataset['index']));
+  }
+
   // This is called every time something is updated in the store.
-  _stateChanged(state) {
+  stateChanged(state) {
     this._products = state.shop.products;
   }
 }


### PR DESCRIPTION
For review:

- Using element class methods without creating a new function each `render()`
- Remove underscore in `stateChanged`

There's an issue with the TS template if I compile pwa-helpers with TS 3.1.1 which I have to look into (currently locked to TS 3.0.3), so will block merging this until I figure that out and cut a stable release for pwa-helpers.

Fixes #245 