### PR TITLE
[do not merge] Update redux; remove window.process

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,10 +74,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           });
         });
       }
-
-      // Redux assumes `process.env.NODE_ENV` exists in the ES module build.
-      // https://github.com/reactjs/redux/issues/2907
-      window.process = { env: { NODE_ENV: 'production' } };
     </script>
 
     <!-- Add any global styles for body, document, etc. -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -19820,11 +19820,11 @@
       "dev": true
     },
     "redux": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
-      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.1.tgz",
+      "integrity": "sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==",
       "requires": {
-        "loose-envify": "^1.1.0",
+        "loose-envify": "^1.4.0",
         "symbol-observable": "^1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@polymer/polymer": "^3.0.0",
     "@webcomponents/webcomponentsjs": "^2.0.0",
     "pwa-helpers": "^0.9.0",
-    "redux": "^4.0.0",
+    "redux": "^4.0.1",
     "redux-thunk": "^2.3.0",
     "reselect": "^3.0.1"
   },

--- a/src/store.js
+++ b/src/store.js
@@ -13,7 +13,7 @@ import {
   compose,
   applyMiddleware,
   combineReducers
-} from 'redux';
+} from 'redux/es/redux.mjs';
 import thunk from 'redux-thunk';
 import { lazyReducerEnhancer } from 'pwa-helpers/lazy-reducer-enhancer.js';
 

--- a/test/unit/views-a11y.html
+++ b/test/unit/views-a11y.html
@@ -15,12 +15,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <title>views a11y</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <script>
-      // Redux assumes `process.env.NODE_ENV` exists in the ES module build.
-      // https://github.com/reactjs/redux/issues/2907
-      window.process = { env: { NODE_ENV: 'production' } };
-    </script>
-
     <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
     <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
 


### PR DESCRIPTION
Can finally remove the `window.process = ` hack.

Do not merge until `polymer build` handles .mjs files.