### PR TITLE
Use gulp task to run `tsc --watch` and `polymer serve` in parallel

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ const gulp = require('gulp');
 const rename = require('gulp-rename');
 const replace = require('gulp-replace');
 const del = require('del');
+const spawn = require('child_process').spawn;
 
 /**
  * Cleans the prpl-server build in the server directory.
@@ -41,3 +42,17 @@ gulp.task('prpl-server', gulp.series(
   'prpl-server:clean',
   'prpl-server:build'
 ));
+
+/**
+ * Gulp task to run `tsc --watch` and `polymer serve` in parallel.
+ */
+gulp.task('serve', () => {
+  const spawnOptions = {
+    // `shell` option for Windows compatability. See:
+    // https://nodejs.org/api/child_process.html#child_process_spawning_bat_and_cmd_files_on_windows
+    shell: true,
+    stdio: 'inherit'
+  };
+  spawn('tsc', ['--watch'], spawnOptions);
+  spawn('polymer', ['serve'], spawnOptions);
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "BSD-3-Clause",
   "repository": "Polymer/pwa-starter-kit",
   "scripts": {
-    "start": "tsc && polymer serve",
+    "start": "gulp serve",
     "build": "tsc && npm run build:prpl-server && npm run build:static",
     "build:prpl-server": "polymer build --auto-base-path && gulp prpl-server",
     "build:static": "polymer build",


### PR DESCRIPTION
Opted to use gulp instead so we wouldn't need to install any more dev dependencies.

Fixes #244