### PR TITLE
docs(deploy): Add information about firebase hosting and sw

### DIFF
--- a/building-and-deploying.md
+++ b/building-and-deploying.md
@@ -194,6 +194,17 @@ Create a Firebase config file (`firebase.json`) with the following:
         "source": "**/!(*.*)",
         "destination": "/index.html"
       }
+    ],
+     "headers": [
+      { 
+        "source":"/service-worker.js", 
+        "headers": [
+          {
+            "key": "Cache-Control", 
+            "value": "no-cache"
+          }
+        ] 
+      }
     ]
   }
 }


### PR DESCRIPTION
Hello folks,

I add a little line in the configuration for firebase hosting (static) that set `no-cache` header for the service worker file (causes a lot of pain to be honest 🙄 )

Cheers !
