### PR TITLE
travis use node 10 as it is the latest supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 matrix:
   include:
-  - node_js: '9'
+  - node_js: '10'
     os: osx
     script: npm run test:integration
-  - node_js: '9'
+  - node_js: '10'
     sudo: required
     os: linux
     dist: trusty


### PR DESCRIPTION
Based on documentation seen in link below, the current supported versions are node 8 and 10. Travis uses version 9 for the moment, and should follow Polymer official support.

https://polymer-library.polymer-project.org/3.0/docs/tools/node-support