### PR TITLE
Make prpl-server the default build/serve target

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
   "repository": "Polymer/pwa-starter-kit",
   "scripts": {
     "start": "polymer serve",
-    "build": "npm run build:prpl-server && npm run build:static",
-    "build:prpl-server": "polymer build --auto-base-path && gulp prpl-server",
+    "build": "polymer build --auto-base-path && gulp prpl-server",
     "build:static": "polymer build",
-    "serve:prpl-server": "prpl-server --root server/build",
+    "serve": "prpl-server --root server/build",
     "serve:static": "polymer serve --port 5000 build/es5-bundled",
     "test": "npm run test:unit && npm run test:integration",
     "test:integration": "mocha test/integration --timeout=10000",


### PR DESCRIPTION
(Opening this PR for consideration and discussion.)

Instead of having `npm run build` make both prpl-server and static builds, this will make prpl-server the default build and `npm run build:static` for the static build (and similarly for `serve`/`serve:static`). Having this default means users don't have to decide between `serve:prpl-server` and `serve:static` when first working with the project (which can be confusing).