### PR TITLE
[webpack branch] Always load wc-bundle

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,8 +108,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <noscript>
       Please enable JavaScript to view this website.
     </noscript>
-    <!-- Load webcomponents-loader.js to check and load any polyfills your browser needs -->
-    <script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
     <!-- Built with love using PWA Starter Kit -->
   </body>
 </html>

--- a/src/index.js
+++ b/src/index.js
@@ -9,13 +9,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 */
 
 /**
- * NOTE(keanulee): Ideally we would just `import '@babel/polyfill'` and rely
- * on babel-preset-env's useBuiltIns
- * (https://babeljs.io/docs/en/babel-preset-env#usebuiltins) to detect language
- * features, but webcomponents-sd-ce-pf.js already imports some language
- * features, such as Symbol, which conflicts with '@babel/polyfill'. So
- * instead, we just import the features we know we need.
+ * NOTE(keanulee): Must import `@babel/polyfill` before
+ * `webcomponents-bundle.js` as both import some language features, such as
+ * Symbol, and conflicts when loaded in a different order.
  */
-import 'regenerator-runtime/runtime';
+import '@babel/polyfill';
 import '@webcomponents/webcomponentsjs/custom-elements-es5-adapter.js';
+import '@webcomponents/webcomponentsjs/webcomponents-bundle.js';
 import './components/my-app.js';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,10 @@ module.exports = {
           loader: 'babel-loader',
           options: {
             presets: [
-              ['@babel/preset-env', {targets: {ie: '11'}}]
+              ['@babel/preset-env', {
+                targets: {ie: '11'},
+                useBuiltIns: 'entry'
+              }]
             ],
             plugins: ['@babel/plugin-syntax-dynamic-import']
           }
@@ -36,7 +39,6 @@ module.exports = {
   plugins: [
     new CopyWebpackPlugin([
       'images/**',
-      'node_modules/@webcomponents/webcomponentsjs/**',
       'manifest.json'
     ]),
     new HtmlWebpackPlugin({
@@ -45,16 +47,11 @@ module.exports = {
     }),
     new WorkboxWebpackPlugin.GenerateSW({
       include: ['index.html', 'manifest.json', /\.js$/],
-      exclude: [/\/@webcomponents\/webcomponentsjs\//],
       navigateFallback: 'index.html',
       swDest: 'service-worker.js',
       clientsClaim: true,
       skipWaiting: true,
       runtimeCaching: [
-        {
-          urlPattern: /\/@webcomponents\/webcomponentsjs\//,
-          handler: 'staleWhileRevalidate'
-        },
         {
           urlPattern: /^https:\/\/fonts.gstatic.com\//,
           handler: 'staleWhileRevalidate'


### PR DESCRIPTION
(For consideration:)

Instead of using webcomponents-loader, always import webcomponents-bundle. This removes the need of copying the `node_modules/@webcomponents/webcomponentsjs/` directory and allows the use of `import '@babel/polyfill'`, but at the cost of increasing the initial view1 JS from 71KB to 133KB on Chrome (since wc-bundle is always loaded).