### PR TITLE
Change `apple-mobile-web-app-status-bar-style` to `default`

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <!-- Add to homescreen for Safari on iOS -->
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+    <meta name="apple-mobile-web-app-status-bar-style" content="default">
     <meta name="apple-mobile-web-app-title" content="My App">
 
     <!-- Homescreen icons -->


### PR DESCRIPTION
Currently the starter kit has a meta tag `apple-mobile-web-app-status-bar-style` and it's set to `black-translucent`. The `black-translucent` setting makes the iOS status bar (when the app runs in full-screen mode) to have white text and the same background color as the body of the web app. Unfortunately the text color will remain white even if you use a light background color. This doesn't work well with pwa-starter-kit as it has a white background. We should change the setting to `default` (white background with black text).

After the change:

<img src="https://user-images.githubusercontent.com/116360/51221703-73c43680-18ef-11e9-8ca6-9abb8993705b.jpeg" width="50%">
