### PR TITLE
Make App Engine Standard environment the default

### DIFF
--- a/server/.gcloudignore
+++ b/server/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/server/app.yaml
+++ b/server/app.yaml
@@ -1,4 +1,5 @@
-runtime: nodejs
-env: flex
-automatic_scaling:
-  min_num_instances: 1
+runtime: nodejs8
+handlers:
+  - url: '.*'
+    script: auto
+    secure: always


### PR DESCRIPTION
This makes App Engine Standard environment the default. This is fine for pwa-starter-kit and its current deployment, though note that current [Shop](https://github.com/Polymer/shop/blob/brotli/server/server.js) and [pwa-starter-kit-hn](https://github.com/Polymer/pwa-starter-kit-hn/blob/push-proxy/server/server.js) deployments still use Flexible environment so that the `shrink-ray-current` middleware for brotli compression works (and an instance is always up for maximum performance).

Fixes #322 