### PR TITLE
Improve secure setting

### DIFF
--- a/server/app.yaml
+++ b/server/app.yaml
@@ -3,3 +3,4 @@ handlers:
   - url: '.*'
     script: auto
     secure: always
+    redirect_http_response_code: 301


### PR DESCRIPTION
"secure: always" allows to redirect http to https with a redirect 302 (temporary).
Add "redirect_http_response_code: 301" allow to perform a redirect 301 (permanent).
See : https://cloud.google.com/appengine/docs/standard/nodejs/application-security#https_requests
See : https://cloud.google.com/appengine/docs/standard/nodejs/config/appref#handlers_secure