### PR TITLE
Fix broken link for "how to get started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ gives you the following features:
 - unit and integrating testing starting points
 - documentation about other advanced patterns.
 
-### 📖 Head over to the [documentation site](https://pwa-starter-kit.polymer-project.org/) for more details or check out [how to get started](https://pwa-starter-kit.polymer-project.org/setup/)!
+### 📖 Head over to the [documentation site](https://pwa-starter-kit.polymer-project.org/) for more details or check out [how to get started](https://pwa-starter-kit.polymer-project.org/setup)!
 
 ![pwa-starter-kit screenshot](https://user-images.githubusercontent.com/1369170/39715580-a1be5126-51e2-11e8-8440-96b07be03a3c.png)
 


### PR DESCRIPTION
This link results in page not found: https://pwa-starter-kit.polymer-project.org/setup/
This link results in how to get started page: https://pwa-starter-kit.polymer-project.org/setup