### PR TITLE
[minimal-ui] Remove style not used on minimal-ui

### DIFF
--- a/src/components/my-app.js
+++ b/src/components/my-app.js
@@ -87,12 +87,6 @@ class MyApp extends connect(store)(LitElement) {
           header {
             flex-direction: row;
           }
-
-          /* The drawer button isn't shown in the wide layout, so we don't
-          need to offset the title */
-          [main-title] {
-            padding-right: 0px;
-          }
         }
       `
     ];


### PR DESCRIPTION
- Remove style not used on minimal-ui

Not related to this pull.
I created two branchs using typescript and minimal-ui template, i don't know if may be useful.
https://github.com/Arenari/pwa-starter-kit/tree/template-typescript-minimal-ui
https://github.com/Arenari/pwa-starter-kit/tree/typescript-minimal-ui-firebase