### PR TITLE
make amount a number, so visibility of span works

### DIFF
--- a/src/components/shop-item.js
+++ b/src/components/shop-item.js
@@ -15,7 +15,7 @@ class ShopItem extends LitElement {
   static get properties() {
     return {
       name: { type: String },
-      amount: { type: String },
+      amount: { type: Number },
       price: { type: String }
     };
   }


### PR DESCRIPTION
The hidden attribute of the span in the render only works when amount is a number:
<span ?hidden="${this.amount === 0}">${this.amount} * </span>